### PR TITLE
clear serial buffer to provide current meter data

### DIFF
--- a/teleinfo.py
+++ b/teleinfo.py
@@ -16,6 +16,9 @@ class Teleinfo:
                 return chr(sum)
                 
         def read (self):
+                # clear serial buffer to provide current meter data
+                self.ser.flushInput()
+
                 # Wait for data
                 while self.ser.read(1) != chr(2): pass
                 


### PR DESCRIPTION
As time passed, I was seeing a larger and larger gap between real meter data and reported meter data.  This is because the FIFO was filling up with the continuous data stream from the meter, however data being read off the stack only periodically (once a minute).

To avoid this, I am flushing the serial input buffer prior to doing the TeleInfo read.

Still certainly not an ideal implementation, but it should more accurate when time stamping and logging energy use data.
